### PR TITLE
Proposal for OC cache type element

### DIFF
--- a/schema.xsd
+++ b/schema.xsd
@@ -38,6 +38,34 @@
         </xs:annotation>
         <xs:complexType>
             <xs:sequence>
+                <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The type of geocache in terms of common Opencaching types;
+                            one of the following:
+
+                            * Traditional Cache
+                            * Multi-cache
+                            * Quiz Cache
+                            * Moving Cache
+                            * Virtual Cache
+                            * Webcam Cache
+                            * Podcast Cache
+                            * Event Cache
+                            * Own Cache
+                            * Other Cache
+
+                            The types "Quiz", "Moving", "Podcast", "Own" and "Other" are
+                            not defined for groundspeak:type and will usually be mapped to
+                            groundspeak:type "Unknown Cache", which usually will be
+                            understood as "Mystery Cache" or "Quiz Cache".
+
+                            More OC types may be added. If you encounter an OC type that
+                            your application does not understand, you should treat it as
+                            "Other Cache".
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
                 <xs:element name="code" type="xs:string" minOccurs="0" maxOccurs="unbounded">
                     <xs:annotation>
                         <xs:documentation>

--- a/schema.xsd
+++ b/schema.xsd
@@ -60,9 +60,7 @@
                             groundspeak:type "Unknown Cache", which usually will be
                             understood as "Mystery Cache" or "Quiz Cache".
 
-                            More OC types may be added. If you encounter an OC type that
-                            your application does not understand, you should treat it as
-                            "Other Cache".
+                            More OC types may be added.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:element>


### PR DESCRIPTION
This is the result of some try-and-error.

I discarded the idea of extending groundspeak:type, because that would create a monster of ~ 30 types, some of them ambiguous. E.g. GS "Unknown Cache" is a superset of OC "Quiz Cache" and OC "Other Cache".

Then I also discarded the OCDE types "Drive-In" and "Math/Physics" and the [five OCUS types](https://github.com/opencaching/opencaching-pl/issues/860), because it is more reasonable to map them to existing types + some attribute.

The result is a subset of 5 Groundspeak types + a subset of 5 OC types, which are all in use at several OC sites.