### PR TITLE
Add 'site_team_entry' flag to grondspeak:log; updates #7

### DIFF
--- a/schema.xsd
+++ b/schema.xsd
@@ -141,5 +141,14 @@
             </xs:documentation>
         </xs:annotation>
     </xs:element>
+    <xs:element name="site_team_entry" type="xs:boolean">
+        <xs:annotation>
+            <xs:documentation>
+                This element is supposed to be added as a child of the groundspeak:log element.
+                If true, it expresses that the log entry has been "officially" made by a
+                member of the Opencaching site's team.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
 
 </xs:schema>


### PR DESCRIPTION
The best place for this flag would be an attribute of the `groundspeak:type` element of log entries, because it is closely related to the log type. OCPL has an own "OC team comment" log type, and OCPL displays the team-entry flag besides of the log type.

But probably there are some broken apps out there which do no XML parsing but just some crude text parsing of GPX files (that's how I started parsing XML in my own apps ;). They could be broken if we insert an attribute into `<groundspeak:type>`. Hence the proposal to add is as separate element to `groundspeak:log`.